### PR TITLE
Fix capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To install Pokedex using Bun, follow these steps:
    ```
 2. Navigate to the project directory:
    ```bash
-   cd pokedex
+   cd Pokedex
    ```
 3. Install the necessary packages using Bun:
    ```bash


### PR DESCRIPTION
## Summary
- fix the installation instructions to use the correct directory name

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6876043aaadc8320bf7e4962e8fa44d1