### PR TITLE
Improve filtering and add detail view

### DIFF
--- a/src/Pokedex.css
+++ b/src/Pokedex.css
@@ -47,6 +47,21 @@
     padding: 1rem;
 }
 
+.filters {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+}
+
+.filters input,
+.filters select {
+    padding: 0.5rem;
+    border-radius: 5px;
+    border: 1px solid #ccc;
+}
+
 /* Responsive design */
 @media (max-width: 768px) {
     .search-input {

--- a/src/Pokedex.js
+++ b/src/Pokedex.js
@@ -1,10 +1,18 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import axios from 'axios';
 import './Pokedex.css';
+import PokemonDetail from './PokemonDetail';
 
 function Pokedex() {
   const [pokemons, setPokemons] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
+  const [selectedType, setSelectedType] = useState('');
+  const [selectedGeneration, setSelectedGeneration] = useState('');
+  const [abilityQuery, setAbilityQuery] = useState('');
+  const [minAttack, setMinAttack] = useState(0);
+  const [types, setTypes] = useState([]);
+  const [generations, setGenerations] = useState([]);
+  const [selectedPokemon, setSelectedPokemon] = useState(null);
   const [offset, setOffset] = useState(0);
   const [hasMore, setHasMore] = useState(true);
   const loader = useRef(null);
@@ -24,11 +32,31 @@ function Pokedex() {
     const results = await Promise.all(
       response.data.results.map(pokemon => axios.get(pokemon.url))
     );
-    setPokemons(prev => [...prev, ...results.map(r => r.data)]);
+    const withSpecies = await Promise.all(
+      results.map(r => axios.get(r.data.species.url))
+    );
+    setPokemons(prev => [
+      ...prev,
+      ...results.map((r, i) => ({ ...r.data, species: withSpecies[i].data })),
+    ]);
   }, [offset, hasMore]);
 
   useEffect(() => {
     loadPokemons();
+  }, []);
+
+  useEffect(() => {
+    async function loadFilters() {
+      try {
+        const typeRes = await axios.get('https://pokeapi.co/api/v2/type?limit=100');
+        setTypes(typeRes.data.results);
+        const genRes = await axios.get('https://pokeapi.co/api/v2/generation?limit=100');
+        setGenerations(genRes.data.results);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    loadFilters();
   }, []);
 
   useEffect(() => {
@@ -53,6 +81,28 @@ function Pokedex() {
     setSearchQuery(event.target.value.toLowerCase());
   }
 
+  const filteredPokemons = pokemons
+    .filter(pokemon => pokemon.name.includes(searchQuery))
+    .filter(pokemon =>
+      selectedType ? pokemon.types.some(t => t.type.name === selectedType) : true
+    )
+    .filter(pokemon =>
+      selectedGeneration
+        ? pokemon.species.generation.name === selectedGeneration
+        : true
+    )
+    .filter(pokemon =>
+      abilityQuery
+        ? pokemon.abilities.some(a =>
+            a.ability.name.toLowerCase().includes(abilityQuery)
+          )
+        : true
+    )
+    .filter(pokemon => {
+      const attack = pokemon.stats.find(s => s.stat.name === 'attack');
+      return attack ? attack.base_stat >= minAttack : true;
+    });
+
 
 
   return (
@@ -61,23 +111,64 @@ function Pokedex() {
         type="text"
         placeholder="Search Pokémon"
         className="search-input"
-        onChange={handleSearchChange} // We will define this function next
+        onChange={handleSearchChange}
       />
-      <div className="pokemon-grid">
-        {pokemons
-          .filter(pokemon => pokemon.name.includes(searchQuery))
-          .map(pokemon => (
-            <div key={pokemon.id} className="pokemon-card">
-              <img
-                src={pokemon.sprites.front_default}
-                alt={pokemon.name}
-                loading="lazy"
-              />
-              <p>{pokemon.name}</p>
-            </div>
+      <div className="filters">
+        <select onChange={e => setSelectedType(e.target.value)} value={selectedType}>
+          <option value="">All Types</option>
+          {types.map(t => (
+            <option key={t.name} value={t.name}>
+              {t.name}
+            </option>
           ))}
+        </select>
+        <select
+          onChange={e => setSelectedGeneration(e.target.value)}
+          value={selectedGeneration}
+        >
+          <option value="">All Generations</option>
+          {generations.map(g => (
+            <option key={g.name} value={g.name}>
+              {g.name}
+            </option>
+          ))}
+        </select>
+        <input
+          type="text"
+          placeholder="Ability"
+          value={abilityQuery}
+          onChange={e => setAbilityQuery(e.target.value.toLowerCase())}
+        />
+        <input
+          type="number"
+          placeholder="Min Attack"
+          value={minAttack}
+          onChange={e => setMinAttack(Number(e.target.value))}
+        />
+      </div>
+      <div className="pokemon-grid">
+        {filteredPokemons.map(pokemon => (
+          <div
+            key={pokemon.id}
+            className="pokemon-card"
+            onClick={() => setSelectedPokemon(pokemon)}
+          >
+            <img
+              src={pokemon.sprites.front_default}
+              alt={pokemon.name}
+              loading="lazy"
+            />
+            <p>{pokemon.name}</p>
+          </div>
+        ))}
       </div>
       {hasMore && <div ref={loader} className="loading">Loading...</div>}
+      {selectedPokemon && (
+        <PokemonDetail
+          pokemon={selectedPokemon}
+          onClose={() => setSelectedPokemon(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/PokemonDetail.css
+++ b/src/PokemonDetail.css
@@ -1,0 +1,32 @@
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+}
+
+.modal-content {
+  background: white;
+  padding: 2rem;
+  border-radius: 8px;
+  max-width: 600px;
+  width: 90%;
+}
+
+.close-button {
+  float: right;
+  background: transparent;
+  border: none;
+  font-size: 1rem;
+}
+
+.moves-list {
+  max-height: 200px;
+  overflow-y: auto;
+}

--- a/src/PokemonDetail.js
+++ b/src/PokemonDetail.js
@@ -1,0 +1,91 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import './PokemonDetail.css';
+
+function PokemonDetail({ pokemon, onClose }) {
+  const [evolution, setEvolution] = useState([]);
+  const [typeEffectiveness, setTypeEffectiveness] = useState({});
+
+  useEffect(() => {
+    async function fetchExtra() {
+      try {
+        const speciesRes = await axios.get(pokemon.species.url);
+        const evoRes = await axios.get(speciesRes.data.evolution_chain.url);
+        const chainList = [];
+        function traverse(node, stage = 1) {
+          chainList.push({ name: node.species.name, stage });
+          node.evolves_to.forEach(n => traverse(n, stage + 1));
+        }
+        traverse(evoRes.data.chain);
+        setEvolution(chainList);
+
+        const rel = { weak: new Set(), resistant: new Set(), immune: new Set() };
+        for (const t of pokemon.types) {
+          const typeData = await axios.get(t.type.url);
+          typeData.data.damage_relations.double_damage_from.forEach(x => rel.weak.add(x.name));
+          typeData.data.damage_relations.half_damage_from.forEach(x => rel.resistant.add(x.name));
+          typeData.data.damage_relations.no_damage_from.forEach(x => rel.immune.add(x.name));
+        }
+        setTypeEffectiveness({
+          weak: Array.from(rel.weak),
+          resistant: Array.from(rel.resistant),
+          immune: Array.from(rel.immune),
+        });
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    fetchExtra();
+  }, [pokemon]);
+
+  return (
+    <div className="modal">
+      <div className="modal-content">
+        <button className="close-button" onClick={onClose}>
+          Close
+        </button>
+        <h2>{pokemon.name}</h2>
+        <img src={pokemon.sprites.front_default} alt={pokemon.name} />
+        <h3>Stats</h3>
+        <ul>
+          {pokemon.stats.map(s => (
+            <li key={s.stat.name}>
+              {s.stat.name}: {s.base_stat}
+            </li>
+          ))}
+        </ul>
+        <h3>Abilities</h3>
+        <ul>
+          {pokemon.abilities.map(a => (
+            <li key={a.ability.name}>
+              {a.ability.name}
+              {a.is_hidden ? ' (Hidden)' : ''}
+            </li>
+          ))}
+        </ul>
+        <h3>Evolution Chain</h3>
+        <ul>
+          {evolution.map(e => (
+            <li key={e.name}>
+              Stage {e.stage}: {e.name}
+            </li>
+          ))}
+        </ul>
+        <h3>Moves</h3>
+        <ul className="moves-list">
+          {pokemon.moves.map(m => (
+            <li key={m.move.name}>
+              {m.move.name} - {m.version_group_details[0].move_learn_method.name}
+            </li>
+          ))}
+        </ul>
+        <h3>Type Effectiveness</h3>
+        <p>Weak to: {typeEffectiveness.weak && typeEffectiveness.weak.join(', ')}</p>
+        <p>Resistant to: {typeEffectiveness.resistant && typeEffectiveness.resistant.join(', ')}</p>
+        <p>Immune to: {typeEffectiveness.immune && typeEffectiveness.immune.join(', ')}</p>
+      </div>
+    </div>
+  );
+}
+
+export default PokemonDetail;


### PR DESCRIPTION
## Summary
- allow filtering Pokémon by type, generation, ability and base attack
- include dropdowns for types and generations
- fetch species info for each Pokémon
- open a modal with detailed information when a card is clicked
- style new filters and detail modal

## Testing
- `bun test` *(fails: Cannot find module 'react/jsx-dev-runtime')*

------
https://chatgpt.com/codex/tasks/task_e_6876b06cce0483209ac3a3f8531ccb26